### PR TITLE
linux: Drop S = "${WORKDIR}/git" override

### DIFF
--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -8,7 +8,6 @@ PV = "${LINUX_VERSION}"
 
 LINUX_MAINLINE_GIT_URI ?= "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=https"
 SRC_URI = "${LINUX_MAINLINE_GIT_URI};branch=master"
-S = "${WORKDIR}/git"
 
 DEPENDS += "libyaml-native python3-dtschema-wrapper-native"
 inherit pkgconfig

--- a/recipes-kernel/linux/linux-stable.inc
+++ b/recipes-kernel/linux/linux-stable.inc
@@ -10,4 +10,3 @@ PV = "${LINUX_VERSION}"
 
 LINUX_STABLE_GIT_URI ?= "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;protocol=https"
 SRC_URI = "${LINUX_STABLE_GIT_URI};branch=${LINUX_STABLE_BRANCH}"
-S = "${WORKDIR}/git"


### PR DESCRIPTION
This is relevant for Styhead+

Fixes: https://github.com/betafive/meta-linux-mainline/issues/43

```
Since oe-core unpacks to UNPACKDIR instead of WORKDIR, this override leaves the shared kernel-source directory empty and make-mod-scripts fails with

  make: *** No rule to make target 'prepare'.  Stop.

Drop it so kernel.bbclass's default S = "${STAGING_KERNEL_DIR}" is used and the source lands in the shared tree.
```